### PR TITLE
Gsa 21 hamburger menu transition

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { MdbModalModule } from 'mdb-angular-ui-kit/modal';
+import { PdfViewerModule } from 'ng2-pdf-viewer';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -12,8 +15,7 @@ import { ProjectsComponent } from './components/contents/projects/projects/proje
 import { ContactComponent } from './components/contents/contact/contact/contact.component';
 import { ContentsComponent } from './pages/contents/contents.component';
 import { ModalComponent } from './components/modal/modal.component';
-import { MdbModalModule } from 'mdb-angular-ui-kit/modal';
-import { PdfViewerModule } from 'ng2-pdf-viewer';
+
 
 @NgModule({
   declarations: [
@@ -33,6 +35,7 @@ import { PdfViewerModule } from 'ng2-pdf-viewer';
     AppRoutingModule,
     MdbModalModule,
     PdfViewerModule,
+    BrowserAnimationsModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -12,11 +12,9 @@
 <!-- Mobile version: Start -->
 <div class="navbar-mobile">
   <nav class="navigation-section">
-    <!-- <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [ngStyle]="{ 'display' : clicked == true ?  'none' : 'block'}"> -->
     <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [@openClose]="clicked == true ? 'close': 'open'">
       <img [src]="hamburger_menu_open">
     </div>
-    <!-- <div class="burger-menu-block-section" (click)="hamburgerMenuChangeState(false)" [ngStyle]="{ 'display' : clicked == false ?  'none' : 'block'}"> -->
       <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(false)" [@openClose]="clicked == false ? 'close': 'open'">
       <div class="hamburger-menu-close">
         <img [src]="hamburger_menu_close">

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -12,10 +12,12 @@
 <!-- Mobile version: Start -->
 <div class="navbar-mobile">
   <nav class="navigation-section">
-    <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [ngStyle]="{ 'display' : clicked == true ?  'none' : 'block'}">
+    <!-- <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [ngStyle]="{ 'display' : clicked == true ?  'none' : 'block'}"> -->
+    <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [@openClose]="clicked == true ? 'close': 'open'">
       <img [src]="hamburger_menu_open">
     </div>
-    <div class="burger-menu-block-section" (click)="hamburgerMenuChangeState(false)" [ngStyle]="{ 'display' : clicked == false ?  'none' : 'block'}">
+    <!-- <div class="burger-menu-block-section" (click)="hamburgerMenuChangeState(false)" [ngStyle]="{ 'display' : clicked == false ?  'none' : 'block'}"> -->
+      <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(false)" [@openClose]="clicked == false ? 'close': 'open'">
       <div class="hamburger-menu-close">
         <img [src]="hamburger_menu_close">
       </div>

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -1,10 +1,42 @@
 import { Component, OnInit } from '@angular/core';
 import { NavigationService } from 'src/app/services/navigation.service';
+import { trigger, state, style, animate, transition } from '@angular/animations';
 
 @Component({
   selector: 'app-navigation',
   templateUrl: './navigation.component.html',
-  styleUrls: ['./navigation.component.scss']
+  styleUrls: ['./navigation.component.scss'],
+  animations: [
+    trigger('openClose', [
+
+      state('open', style({
+        display: 'block',
+      })),
+
+      state('close', style({
+        display: 'none'
+      })),
+
+      transition('open => closed', [
+        animate("3s ease-in")
+      ]),
+      transition('closed => open', [
+        animate("0s")
+      ]),
+    ]),
+  ]
+
+//   // On click
+// // Open overlay: "About";
+// // Animate: Move in Bottom;
+// animation-timing-function: ease-in;
+// animation-duration: 300ms;
+
+// // While hovering
+// // Open overlay: "About";
+// // Animate: Instant;
+// animation-duration: 0ms;
+
 })
 export class NavigationComponent implements OnInit {
   clicked: Boolean;

--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -25,19 +25,8 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
       ]),
     ]),
   ]
-
-//   // On click
-// // Open overlay: "About";
-// // Animate: Move in Bottom;
-// animation-timing-function: ease-in;
-// animation-duration: 300ms;
-
-// // While hovering
-// // Open overlay: "About";
-// // Animate: Instant;
-// animation-duration: 0ms;
-
 })
+
 export class NavigationComponent implements OnInit {
   clicked: Boolean;
   hamburger_menu_open = '../../../assets/uploads/Hamburger Menu.png';


### PR DESCRIPTION
Steps taken:
- Enable`BrowserAnimationsModule` into the root app module
- import animation functions into the navigation component ts 
- add animation metadata property 
- implement transitions and CSS styles
- In the HTML template, implement property binding that calls the trigger function name and passes with a given condition

Output:
- There is still a bug when opening the nav-items block. I would say it is 90% working

Reference:
https://angular.io/guide/animations#step-1-enabling-the-animations-module

Closes #21 