### PR TITLE
style(navbar): fix misspelled metadata value

### DIFF
--- a/src/app/components/navigation/navigation.component.ts
+++ b/src/app/components/navigation/navigation.component.ts
@@ -17,11 +17,11 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
         display: 'none'
       })),
 
-      transition('open => closed', [
-        animate("3s ease-in")
+      transition('open => close', [
+        animate("1s ease-in")
       ]),
-      transition('closed => open', [
-        animate("0s")
+      transition('close => open', [
+        animate("1s ease-out")
       ]),
     ]),
   ]


### PR DESCRIPTION
Steps taken: 
- In  the navigation.component.ts, I corrected the misspelled value passed from the transition property

Closes #28 