### PR TITLE
Gsa 35 add two templates

### DIFF
--- a/src/client/src/app/components/contents/contact/contact/contact.component.html
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.html
@@ -21,6 +21,9 @@
       </div>
     </div>
 </div>
+<div [ngStyle]="displaySuccessTemplate()"></div>
+<div [ngStyle]="displayErrorTemplate()"></div>
 <div class="contact-image-section">
   <img [src]="contact_me_image" alt="">
 </div>
+

--- a/src/client/src/app/components/contents/contact/contact/contact.component.html
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.html
@@ -21,8 +21,8 @@
       </div>
     </div>
 </div>
-<div [ngStyle]="displaySuccessTemplate()">Message sent! </div>
-<div [ngStyle]="displayErrorTemplate()">Error! There is an issue. Please try again.</div>
+<div [ngStyle]="isSent == true ? displaySuccessTemplate() : {'display' : 'none'}" >Message sent! </div>
+<div [ngStyle]="hasError == true ? displayErrorTemplate() : {'display' : 'none'}" >Error! There is an issue. Please try again.</div>
 <div class="contact-image-section">
   <img [src]="contact_me_image" alt="">
 </div>

--- a/src/client/src/app/components/contents/contact/contact/contact.component.html
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.html
@@ -21,8 +21,8 @@
       </div>
     </div>
 </div>
-<div [ngStyle]="displaySuccessTemplate()"></div>
-<div [ngStyle]="displayErrorTemplate()"></div>
+<div [ngStyle]="displaySuccessTemplate()">Message sent! </div>
+<div [ngStyle]="displayErrorTemplate()">Error! There is an issue. Please try again.</div>
 <div class="contact-image-section">
   <img [src]="contact_me_image" alt="">
 </div>

--- a/src/client/src/app/components/contents/contact/contact/contact.component.ts
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
-import { KeyLike } from 'crypto';
-import { of } from 'rxjs';
 import { ContactusService } from 'src/app/services/contactus.service';
+
 
 @Component({
   selector: 'app-contact',
@@ -14,6 +13,7 @@ export class ContactComponent implements OnInit {
   contactForm: FormGroup;
   contact_me_image = "../../../../../assets/uploads//contact-me.png";
   isSent: Boolean = false
+  hasError: Boolean = false
 
   constructor(private fb: FormBuilder, private contactusService: ContactusService) {
 
@@ -43,12 +43,22 @@ export class ContactComponent implements OnInit {
         next: () => {
           console.log("Res: ", contactUs.from)
           console.log("Res: ", contactUs.html)
+          this.isSent = true
+          this.hasError = false
         },
-        error: (err) => console.log("Errorzzzzz: ", err ),
-        complete: () => this.contactForm.reset()
+        error: (err) => {
+          console.log("Errorzzzzz: ", err )
+          this.isSent = false
+          this.hasError = true
+        },
+        complete: () => {
+          this.contactForm.reset();
+        }
       })
     }else {
       console.log('One of the fields is invalid!')
+      this.isSent = false
+      this.hasError = true
     }
   }
 

--- a/src/client/src/app/components/contents/contact/contact/contact.component.ts
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { KeyLike } from 'crypto';
 import { of } from 'rxjs';
 import { ContactusService } from 'src/app/services/contactus.service';
 
@@ -12,6 +13,7 @@ export class ContactComponent implements OnInit {
 
   contactForm: FormGroup;
   contact_me_image = "../../../../../assets/uploads//contact-me.png";
+  isSent: Boolean = false
 
   constructor(private fb: FormBuilder, private contactusService: ContactusService) {
 
@@ -52,5 +54,21 @@ export class ContactComponent implements OnInit {
 
   resetEmail(){
     this.contactForm.reset();
+  }
+
+  displaySuccessTemplate() {
+    return {
+      'background-color': 'goldenrod',
+      'width' : '300px',
+      'height' : '200px'
+    }
+  }
+
+  displayErrorTemplate(){
+    return {
+      'background-color': 'red',
+      'width' : '300px',
+      'height' : '200px'
+    }
   }
 }


### PR DESCRIPTION
## Changes
1. Add two functions that hold CSS properties as an object. Styles added are temporary
2. use `ngStyle` with ternary conditions
3. add flags so I can use those with ngStyle and implement the distinct function if specific conditions are met else the template is hidden

## Purpose
Create two templates that will only display if the message is sent successfully or if there is an error

## Approach
User will know if their message went through or if they need to re-enter their message again

## Learning
https://stackoverflow.com/questions/37051496/combine-ngstyle-with-condition-if-else

Closes #35 
