### PR TITLE
Gsa 59 templates animation effect

### DIFF
--- a/src/client/src/app/components/contents/contact/contact/contact.component.html
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.html
@@ -29,9 +29,10 @@
       </div>
     </div>
 </div>
-<div [ngStyle]="isSent == true ? displaySuccessTemplate() : hideTemplate()" >Sent Successfully! Talk to you soon </div>
-<div [ngStyle]="hasError == true ? displayErrorTemplate() : hideTemplate()" >Sent Failed! Check the required fields and try again </div>
+<div class ="confirmation-template" [ngStyle]="isSent == true ? displaySuccessTemplate() : hideTemplate()" >Sent Successfully! Talk to you soon </div>
+<div class ="confirmation-template" [ngStyle]="hasError == true ? displayErrorTemplate() : hideTemplate()" >Sent Failed! Check the required fields and try again </div>
 <div class="contact-image-section">
   <img [src]="contact_me_image" alt="">
 </div>
+
 

--- a/src/client/src/app/components/contents/contact/contact/contact.component.scss
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.scss
@@ -63,7 +63,7 @@
       gap: 1.25rem;
       justify-content: center;
 
-      .send-button-block .send-button, .reset-button-block .reset-button {
+      .send-button-block .send-button .reset-button-block .reset-button {
         padding: 15px 60px;
       }
     }
@@ -110,7 +110,7 @@
         flex-direction: column;
         align-items: center;
 
-        .send-button-block .send-button, .reset-button-block .reset-button {
+        .send-button-block .send-button .reset-button-block .reset-button {
           width: 200px;
           max-width: 100%;
           display: flex;
@@ -119,9 +119,21 @@
       }
     }
   }
-  .contact-image-section {
+  .contact-image-section{
     padding: 0 50px;
   }
 }
 
 
+// CSS styles for the two confirmaiton templates
+.confirmation-template{
+  font-family: 'Playfair Display';
+  line-height: 1.5%;
+  font-size: 1.25rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: auto;
+  max-width : 70%;
+  padding: 1.5rem 2rem;
+}

--- a/src/client/src/app/components/contents/contact/contact/contact.component.ts
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.ts
@@ -15,6 +15,11 @@ export class ContactComponent implements OnInit {
   isSent: Boolean = false
   hasError: Boolean = false
 
+  hiddenTemplateStyle = {
+    'opacity': '0',
+    'transition' : 'all 2s ease-out'
+  }
+
   constructor(private fb: FormBuilder, private contactusService: ContactusService) {
 
     this.contactForm = this.fb.group({
@@ -54,7 +59,6 @@ export class ContactComponent implements OnInit {
           this.isSent = true
         },
         error: (err) => {
-          console.log("Errorzzzzz: ", err )
           this.isSent = false
           this.hasError = true
         },
@@ -73,45 +77,39 @@ export class ContactComponent implements OnInit {
     this.contactForm.reset();
   }
 
-  displaySuccessTemplate() {
+ displaySuccessTemplate() {
+
+    setTimeout(()=>{
+      this.isSent = false;
+    }, 5000);
+
     return {
       'background': '#FFFFFF',
       'border': '2px solid #27672D',
-      'font-family': 'Playfair Display',
-      'line-height': '1.5%',
-      'font-size': '1.25rem',
       'color': '#27672D',
-      'display': 'flex',
-      'justify-content': 'center',
-      'align-items': 'center',
-      'margin': 'auto',
-      'max-width' : '70%',
-      "padding": '1.5rem 2rem',
+      'opacity': '1',
+      'transition': 'all 1s ease-out'
     }
+
   }
 
   displayErrorTemplate(){
+    setTimeout(()=>{
+      this.hasError = false;
+    }, 3000);
+
     return {
       'background': '#FFFFFF',
       'border': '2px solid #AC1818',
-      'font-family': 'Playfair Display',
-      'line-height': '1.5%',
-      'font-size': '1.25rem',
       'color': '#AC1818',
-      'display': 'flex',
-      'justify-content': 'center',
-      'align-items': 'center',
-      'margin': 'auto',
-      'max-width' : '70%',
-      "padding": '1.5rem 2rem',
+      'opacity': '1',
+      'transition': 'all 1s ease-out'
     }
   }
 
 
   hideTemplate(){
-    return {
-      'display': 'none'
-    }
+    return this.hiddenTemplateStyle;
   }
 }
 


### PR DESCRIPTION
## Changes
1. Add a new css class to hold the default style properties of the two templates. This is also to implement the DRY method.
2. In ts file, I used the `transition` property to create some fade-in, fade-out effect on the templates. the purpose is to make the template automatically "close" 
3. In the HTML file, I only changed the passed object with a function name instead for cleaner coding

## Purpose
This is to create a smooth animation effect. The templates (success and error banners) should disappear after about 5 seconds once they appear on the page. This is also to eliminate the need to add a "close" button

## Approach
I wanted to approach it using pure CSS only and setTimeout for learning experience. This will help me gain more confidence in using transition and animation effects. 

## Learning
https://www.delftstack.com/howto/angular/settimeout-function-in-angular/
https://www.w3schools.com/css/css3_animations.asp
https://stackoverflow.com/questions/21388402/fade-out-after-div-content-has-been-shown-using-css
https://blog.hubspot.com/website/css-fade-in

Closes #59 
