### PR TITLE
Gsa 74 social media links

### DIFF
--- a/src/client/src/app/components/contents/header/header/header.component.html
+++ b/src/client/src/app/components/contents/header/header/header.component.html
@@ -18,10 +18,10 @@
       </div>
       <div class="social-media-icons-section">
         <div class="linkedin-icon">
-          <a href="#"> <img src="../../../../../assets/uploads/LinkedIn.png" alt="Portfolio-LinkedIn"></a>
+          <a href="https://www.linkedin.com/in/gichelle-amon/" [target]=socialMediaAnchorProps.target [rel]=socialMediaAnchorProps.rel> <img src="../../../../../assets/uploads/LinkedIn.png" alt="Portfolio-LinkedIn"></a>
         </div>
         <div class="github-icon">
-          <a href="#"> <img src="../../../../../assets/uploads/GitHub.png" alt="Portfolio-Github"></a>
+          <a href="https://github.com/ChelleAmon" [target]=socialMediaAnchorProps.target [rel]=socialMediaAnchorProps.rel> <img src="../../../../../assets/uploads/GitHub.png" alt="Portfolio-Github"></a>
         </div>
       </div>
     </div>

--- a/src/client/src/app/components/contents/header/header/header.component.ts
+++ b/src/client/src/app/components/contents/header/header/header.component.ts
@@ -7,6 +7,11 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HeaderComponent implements OnInit {
 
+  socialMediaAnchorProps = {
+    target: "_blank",
+    rel: "noopener noreferrer"
+  }
+
   constructor() { }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Changes
1. Create an object that holds the social media anchor link's properties such as target and ref
2. In the HTML file, bind the properties into the anchor tag
3. Add social media links to the `href` property

## Purpose
Make social media links clickable and it should open to a new tab and avoid tabnabbing

## Approach


## Learning
https://www.freecodecamp.org/news/how-to-use-html-to-open-link-in-new-tab/

Closes #74 
