### PR TITLE
Gsa 85 navigation state flag

### DIFF
--- a/src/client/src/app/components/navigation/navigation.component.html
+++ b/src/client/src/app/components/navigation/navigation.component.html
@@ -10,42 +10,20 @@
 <!-- Desktop version: End -->
 
 <!-- Mobile version: Start -->
-<!-- <div class="navbar-mobile">
-  <nav class="navigation-section">
-    <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(true)" [@openClose]="clicked == true ? 'close': 'open'">
-      <img [src]="hamburger_menu_open">
-    </div>
-      <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(false)" [@openClose]="clicked == false ? 'close': 'open'">
-      <div class="hamburger-menu-close">
-        <img [src]="hamburger_menu_close">
-      </div>
-      <div class="links-container">
-        <ng-container *ngFor="let navItem of navigationItems">
-          <a [routerLink]="navItem | lowercase" class="navigation-section-link">{{ navItem }}</a>
-        </ng-container>
-      </div>
-    </div>
-  </nav>
-</div> -->
-
 <div class="navbar-mobile">
   <nav class="navigation-section">
-    <!-- <div class="burger-menu-img-section" > -->
         <input type="checkbox" id="toggle" #toggleMenu>
         <label for="toggle" class="hamburger">
           <span class="top"></span>
           <span class="middle"></span>
           <span class="bottom"></span>
         </label>
-    <!-- </div> -->
-    <!-- <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(false)"> -->
       <nav class="links-container">
-        <!-- <ng-container *ngFor="let navItem of navigationItems"> -->
+        <ng-container>
           <a  *ngFor="let navItem of navigationItems" [routerLink]="navItem | lowercase" class="navigation-section-link" (click)="getNavLinkClickState()">
             {{ navItem }}</a>
-        <!-- </ng-container> -->
+        </ng-container>
       </nav>
-    <!-- </div> -->
   </nav>
 </div>
 

--- a/src/client/src/app/components/navigation/navigation.component.html
+++ b/src/client/src/app/components/navigation/navigation.component.html
@@ -31,7 +31,7 @@
 <div class="navbar-mobile">
   <nav class="navigation-section">
     <!-- <div class="burger-menu-img-section" > -->
-        <input type="checkbox" id="toggle" >
+        <input type="checkbox" id="toggle" #toggleMenu>
         <label for="toggle" class="hamburger">
           <span class="top"></span>
           <span class="middle"></span>
@@ -41,7 +41,8 @@
     <!-- <div class="burger-menu-img-section" (click)="hamburgerMenuChangeState(false)"> -->
       <nav class="links-container">
         <!-- <ng-container *ngFor="let navItem of navigationItems"> -->
-          <a  *ngFor="let navItem of navigationItems" [routerLink]="navItem | lowercase" class="navigation-section-link">{{ navItem }}</a>
+          <a  *ngFor="let navItem of navigationItems" [routerLink]="navItem | lowercase" class="navigation-section-link" (click)="getNavLinkClickState()">
+            {{ navItem }}</a>
         <!-- </ng-container> -->
       </nav>
     <!-- </div> -->

--- a/src/client/src/app/components/navigation/navigation.component.ts
+++ b/src/client/src/app/components/navigation/navigation.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { NavigationService } from 'src/app/services/navigation.service';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 
@@ -28,28 +28,21 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
 })
 
 export class NavigationComponent implements OnInit {
-  clicked: Boolean;
   hamburger_menu_open = '../../../assets/uploads/Hamburger Menu.png';
   hamburger_menu_close="../../../assets/uploads/close-navbar.png";
 
   navigationItems = ['Home', 'About', 'Skills', 'Contributions', 'Contact']
 
+  @ViewChild("toggleMenu") toggleMenu!: ElementRef;
+
   constructor(private navigationService: NavigationService) {
-    this.clicked = this.navigationService.isOpen
-   }
+
+  }
 
   ngOnInit(): void {
   }
 
-  hamburgerMenuChangeState(opened: Boolean){
-   const burgerMenuIsOpen = this.navigationService.hamburgerMenuChangeState(opened)
-   this.clicked = this.navigationService.isOpen
-   return burgerMenuIsOpen;
-  }
-
-  openNavLinkPage(){
-    const link = this.navigationService.openNavLinkPage();
-    this.clicked = this.navigationService.isOpen;
-    return link;
+  getNavLinkClickState(event: any = this.navigationService.isOpen){
+    this.toggleMenu.nativeElement.checked = event;
   }
 }

--- a/src/client/src/app/services/navigation.service.ts
+++ b/src/client/src/app/services/navigation.service.ts
@@ -7,13 +7,5 @@ export class NavigationService {
   isOpen: Boolean = false;
 
   constructor() { }
-
-  hamburgerMenuChangeState(flag: Boolean){
-    this.isOpen = flag;
-  }
-
-  openNavLinkPage(){
-    this.isOpen = false;
-  }
 }
 


### PR DESCRIPTION
## Changes
1. In services, I removed all the function blocks except for the state flag variable
2. In the TS file, I used the `@ViewChild` decorator to get the ElementRef passed from the Input field in DOM
3. I created a new function to assign the state flag value that is passed from navigation services to the input's currentTarget.checked value so the menu will "close" automatically once a link is clicked
4. use the `(click)` event binding in HTML and call the function 

## Purpose
Before, when a navLink is clicked, the menu does not close and I have to click the hamburger menu to close the navigation bar. 

## Approach
Now, because of the `@ViewChild` decorator and the ElementRef, I am able to manipulate the checkbox's currentTarget.checked value so the nav menu now automatically closes if a link is clicked. The checkbox is where it controls the hamburger menu icon's behavior.


## Learning
https://www.itsolutionstuff.com/post/angular-get-element-by-id-value-exampleexample.html
https://stackoverflow.com/questions/24464241/how-can-i-clear-a-checkbox-when-a-link-is-clicked
https://stackoverflow.com/questions/47068222/angular-4-checkbox-change-value

Closes #85
