### PR TITLE
Gsa 88 transform social media icons

### DIFF
--- a/src/client/src/app/components/contents/header/header/header.component.html
+++ b/src/client/src/app/components/contents/header/header/header.component.html
@@ -14,7 +14,7 @@
     </div>
     <div class="contact-links-section">
       <div class="get-in-touch-section">
-        <a routerLink="/contact"> Let's get in touch</a>
+        <a [routerLink]="['../contact']"> Let's get in touch</a>
       </div>
       <div class="social-media-icons-section">
         <div class="linkedin-icon">

--- a/src/client/src/app/components/contents/header/header/header.component.html
+++ b/src/client/src/app/components/contents/header/header/header.component.html
@@ -4,13 +4,13 @@
       <p>Hello! I am</p>
     </div>
     <div class="header-section-memoji">
-      <img src="../../../../../assets/uploads/IMG_5879.png" alt="Gichelle Portfolio- Greetings" class="memoji-block">
+      <img [src]=profileProps.src [alt]=profileProps.alt class="memoji-block">
     </div>
     <div class="name-title-section">
-      <h1>Gichelle Amon</h1>
+      <h1> {{headerContents.name}} </h1>
     </div>
     <div class="job-title-section">
-      <h2>Full Stack Software Developer</h2>
+      <h2> {{headerContents.job}} </h2>
     </div>
     <div class="contact-links-section">
       <div class="get-in-touch-section">

--- a/src/client/src/app/components/contents/header/header/header.component.scss
+++ b/src/client/src/app/components/contents/header/header/header.component.scss
@@ -80,14 +80,28 @@
         &:hover, &:focus {
           color: #FFFFFF;
         }
+
+        &:active{
+          color: #495867;
+        }
       }
     }
     .social-media-icons-section {
       @include displayLayout(center, center);
       flex-direction: row;
+      gap: 0.75rem;
 
         .linkedin-icon, .github-icon{
           width: 100%;
+
+          &:hover, &:focus {
+            transform: scale(1.25);
+            transition: all 0.3s ease;
+          }
+
+          &:active {
+            transform: scale(1);
+          }
 
         }
     }

--- a/src/client/src/app/components/contents/header/header/header.component.ts
+++ b/src/client/src/app/components/contents/header/header/header.component.ts
@@ -6,6 +6,15 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent implements OnInit {
+  profileProps= {
+    src: "../../../../../assets/uploads/IMG_5879.png",
+    alt: "Gichelle Portfolio- Greetings"
+  }
+
+  headerContents = {
+    name: "Gichelle Amon",
+    job: "Full-Stack Software Developer"
+  }
 
   socialMediaAnchorProps = {
     target: "_blank",


### PR DESCRIPTION
## Changes
1. Add `transform` css property with `scale()` and applied it to social media icons when hovered/focused
2. Modify the routerLink path for the anchor link "Let us get in touch" so it will go to the correct URL 

## Purpose
Make the social media icons more interactive by adding some hover/focus effects

## Approach
Make the header page more user-friendly and interactive

## Learning

Closes #88
