### PR TITLE
Gsa 99 error messages validators

### DIFF
--- a/src/client/src/app/components/contents/contact/contact/contact.component.html
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.html
@@ -5,19 +5,44 @@
     <div class="form-body-section" [formGroup]="contactForm" >
       <div class="email-address-section">
         <label for="name">Name: </label>
-        <input type="text" name="name" placeholder="Enter your name" formControlName="name">
+        <section class="email-input">
+          <input type="text" name="name" placeholder="Enter your name" formControlName="name">
+          <div class="error-alert" *ngIf="contactForm.get('name')?.invalid && (contactForm.get('name')?.dirty || contactForm.get('name')?.touched)">
+            <span> Please let me know your name :( </span>
+          </div>
+        </section>
       </div>
       <div class="email-address-section">
         <label for="email">Email: </label>
-        <input type="email" name="email" placeholder="Enter your email address" formControlName="email">
+        <section class="email-input">
+          <input type="email" name="email" placeholder="Enter your email address" formControlName="email">
+          <div class="error-alert" *ngIf="contactForm.get('email')?.errors?.['required'] && (contactForm.get('email')?.dirty || contactForm.get('email')?.touched)">
+            <span> Please let me know your email address :( </span>
+          </div>
+          <div class="error-alert" *ngIf="contactForm.get('email')?.errors?.['email'] && (contactForm.get('email')?.dirty || contactForm.get('email')?.touched)">
+            <span> Please re-type with the following format: 'example@example.com'. Thanks! </span>
+          </div>
+        </section>
       </div>
+
       <div class="email-address-section">
         <label for="phone">Phone: </label>
-        <input type="text" name="phone" placeholder="Enter your phone number. No worries, it is optional" formControlName="phone">
+        <section class="email-input">
+          <input type="text" name="phone" placeholder="Enter your phone number. No worries, this is optional" formControlName="phone">
+          <div class="error-alert" *ngIf="contactForm.get('phone')?.errors?.['invalidPhone'] && (contactForm.get('phone')?.dirty || contactForm.get('phone')?.touched)">
+            <span> Please re-type with the following format: 012-345-6789. Thanks! </span>
+          </div>
+        </section>
       </div>
       <div class="email-body-section">
         <label for="message">Message: </label>
-        <textarea name="message" id="" cols="18" rows="15" placeholder="Enter your message here" formControlName="message"></textarea>
+        <textarea name="message" id="" cols="18" rows="14" placeholder="Enter your message here" formControlName="message"></textarea>
+        <div class="error-alert" *ngIf="contactForm.get('message')?.errors?.['required'] && (contactForm.get('message')?.dirty || contactForm.get('message')?.touched)">
+          <span> Please leave me a message :( </span>
+        </div>
+        <div class="error-alert" *ngIf="contactForm.get('message')?.errors?.['minLength'] && (contactForm.get('message')?.dirty || contactForm.get('message')?.touched)">
+          <span> The length of your message is too short! </span>
+        </div>
       </div>
       <div class="call-of-action-section">
         <div class="send-button-block">
@@ -29,8 +54,16 @@
       </div>
     </div>
 </div>
-<div class ="confirmation-template" [ngStyle]="isSent == true ? displaySuccessTemplate() : hideTemplate()" >Sent Successfully! Talk to you soon </div>
-<div class ="confirmation-template" [ngStyle]="hasError == true ? displayErrorTemplate() : hideTemplate()" >Sent Failed! Check the required fields and try again </div>
+<div class ="confirmation-template" [ngStyle]="isSent == true ? displaySuccessTemplate() : hideTemplate()" >
+  <span>
+    Sent Successfully! Talk to you soon
+  </span>
+</div>
+<div class ="confirmation-template" [ngStyle]="hasError == true ? displayErrorTemplate() : hideTemplate()" >
+ <span>
+  Sent Failed! Check the required fields and try again
+ </span>
+</div>
 <div class="contact-image-section">
   <img [src]="contact_me_image" alt="">
 </div>

--- a/src/client/src/app/components/contents/contact/contact/contact.component.scss
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.scss
@@ -7,8 +7,8 @@
   flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   max-width: 1200px;
-  margin: 70px auto 20px;
-  padding: 0 70px;
+  margin: 70px auto 0px;
+  padding: 0 50px;
 
   .contact-title-section {
     display: flex;
@@ -19,12 +19,17 @@
   .form-body-section {
     display: flex;
     flex-direction: column;
-    padding: 0 20px;
+    padding: 0;
     gap: 1rem;
+    width: 100%;
+    justify-content: center;
 
     .email-address-section {
       display: flex;
       flex-direction: row;
+      gap: 1rem;
+      max-width: 1200px;
+      width: 100%;
 
       label {
         font-size: 28px;
@@ -34,15 +39,31 @@
         padding-right: 15px;
       }
 
+      .email-input {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 90%;
+
+        .error-alert span {
+          color:red;
+          font-weight: 400;
+          font-size: 20px;
+          line-height: 1.5%;
+        }
+      }
       input {
-        width: 1000px;
-        max-width: 100%;
+        width: 900px;
+        max-width: 80%;
       }
     }
 
     .email-body-section {
       display: flex;
       flex-direction: column;
+      justify-content: center;
+      gap: 0.5rem;
+
 
       label {
         font-size: 28px;
@@ -52,9 +73,15 @@
       }
 
       textarea{
-        margin-bottom: 15px;
-        width: 1200px;
+        width: 900px;
         max-width: 100%;
+      }
+
+      .error-alert span {
+        color:red;
+        font-weight: 400;
+        font-size: 20px;
+        line-height: 1.5%;
       }
     }
     .call-of-action-section{
@@ -93,17 +120,36 @@
         label {
           font-size: 20px;
         }
+
+        .email-input {
+          align-items: center;
+          gap: 0.5rem;
+
+          .error-alert span {
+            font-size: 16px;
+          }
+        }
+        input {
+          max-width: 90%;
+        }
       }
       .email-body-section{
-        gap: 0.5rem;
+        align-items: center;
 
         label {
           font-size: 20px;
           padding: 0;
+          align-self: start;
         }
 
         textarea {
           height: 300px;
+          max-width: 90%;
+        }
+
+        .error-alert span {
+          font-size: 16px;
+          margin: auto;
         }
       }
       .call-of-action-section{
@@ -128,12 +174,22 @@
 // CSS styles for the two confirmaiton templates
 .confirmation-template{
   font-family: 'Playfair Display';
-  line-height: 1.5%;
-  font-size: 1.25rem;
   display: flex;
   justify-content: center;
   align-items: center;
   margin: auto;
   max-width : 70%;
-  padding: 1.5rem 2rem;
+  padding: 15px 20px;
+  flex-wrap: wrap;
+
+  span {
+    font-size: 20px;
+    padding: max-content;
+
+  }
+
+  @media (max-width: $size__standard-mobile) {
+    font-size: 14px;
+    line-height: 170%;
+  }
 }

--- a/src/client/src/app/components/contents/contact/contact/contact.component.ts
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { ContactusService } from 'src/app/services/contactus.service';
 import { validatePhoneNumber } from 'src/shared/phone.validator';
 
@@ -25,20 +25,29 @@ export class ContactComponent implements OnInit {
 
     this.contactForm = this.fb.group({
       name: [
-        '',
-        Validators.compose([Validators.required])
+        '', {
+        validators: Validators.compose([Validators.required]),
+        updateOn: 'blur'
+        }
       ],
       email: [
-        '',
-       Validators.compose([ Validators.required, Validators.email ])
+        '', {
+        validators: Validators.compose([ Validators.required, Validators.email ]),
+        updateOn: 'blur'
+        }
       ],
       phone: [
         '',
-        Validators.compose([validatePhoneNumber()])
+        {
+        validators: [validatePhoneNumber()],
+        updateOn: 'blur'
+        }
       ],
       message: [
-        '',
-       Validators.compose([ Validators.required, Validators.minLength(3)])
+        '', {
+        validators: Validators.compose([ Validators.required, Validators.minLength(3)]),
+        updateOn: 'blur'
+        }
       ]
     })
    }


### PR DESCRIPTION
## Changes
1. Add `updateOn: 'blur'` configuration in the reactive form group so the error message will only display after the user filled the input field.
2. In the HTML file, add template to display the error message once the field is "touched" or "dirty" and the required field is not filled
3. Add and edit out stylings, including layouts and color schemes

## Purpose
Once the user left the input field "touched" or "dirty" and they did not fill up the field with correct format, it should display an error message right away

## Approach
This will allow users to get back to the required field and enter the right text. I utilized the ngIf directive and the other form module classes such as `.ng-dirty`, `.ng-invalid`, `.ng-touched`  to display the error message with stylings

## Learning
https://blog.angular-university.io/angular-custom-validators/
https://ultimatecourses.com/blog/angular-ngif-else-then

Closes #99 
