### PR TITLE
feat(route): configure routerModule wilth `scrollPositionRestoration`…

### DIFF
--- a/src/client/src/app/app-routing.module.ts
+++ b/src/client/src/app/app-routing.module.ts
@@ -21,7 +21,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { scrollPositionRestoration: "enabled" })],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }


### PR DESCRIPTION
## Changes
1. On the Router Module, add extraOption property, `scrollPostionRestoration` to "enabled"

## Purpose
If the user scrolls on the page, opens the hamburger menu, and clicks on any menu links, the page should scroll back to the top. 

## Approach
Angular has a built-in property called `scrollPositionRestoration` where the page automatically scrolls to the top of the page once we click on a navigation link and routes to a new page

## Learning
https://angular.io/api/router/ExtraOptions
https://www.damirscorner.com/blog/posts/20221104-ScrollToTopOnNavigationInAngular.html

Closes #103
