### PR TITLE
ref(skills): adjust gap on both desktop and mobile

### DIFF
--- a/src/client/src/app/components/contents/skills/skills/skills.component.scss
+++ b/src/client/src/app/components/contents/skills/skills/skills.component.scss
@@ -35,7 +35,7 @@
     justify-content: flex-start;
     flex-shrink: 25%;
     flex-flow: column nowrap;
-    gap: 2rem;
+    gap: 2.5rem;
 
     .frontend-block, .other-tools-block {
       max-width: 500px;
@@ -114,7 +114,7 @@
       }
     }
     .tech-skills-blocks-section {
-      gap: 1.25rem;
+      gap: 2rem;
 
       .frontend-block, .other-tools-block, .backend-block, .learning-block {
         padding: 15px 25px;


### PR DESCRIPTION
## Changes
1. Adjust the gap length on both desktop and mobile

## Purpose
Increase the gap length especially if the skills sub-sections scaled in during the hover state

## Approach
The gap will not look weird, especially during the hover state

## Learning

Closes #106
