### PR TITLE
Gsa 107 adjust margin bottom

### DIFF
--- a/src/client/src/app/components/contents/about/about/about.component.scss
+++ b/src/client/src/app/components/contents/about/about/about.component.scss
@@ -8,7 +8,7 @@
 
 #about-me-page {
   max-width: 900px;
-  margin: 100px auto;
+  margin: 70px auto 30px;
   padding: 0 30px;
   border-radius: 100px 10px;
   display: flex;
@@ -119,7 +119,7 @@
   #about-me-page {
     margin-left: 30px;
     margin-right: 30px;
-    padding: 0 18px;
+    padding: 0 20px;
 
     .first-body-section, .second-body-section {
       margin-left: 20px;

--- a/src/client/src/app/components/contents/header/header/header.component.scss
+++ b/src/client/src/app/components/contents/header/header/header.component.scss
@@ -11,7 +11,7 @@
 #header-section {
   max-width: 1200px;
   width: 100%;
-  margin: 30px auto;
+  margin: 30px auto 0px;
   padding: 0 30px;
   display: grid;
   grid-template-columns: 1.10fr 1fr;
@@ -161,6 +161,7 @@
     margin-top: 25px;
     justify-content: center;
     flex-direction: column;
+    margin-bottom: 30px;
     order: 5;
 
     .get-in-touch-section {

--- a/src/client/src/app/components/contents/skills/skills/skills.component.scss
+++ b/src/client/src/app/components/contents/skills/skills/skills.component.scss
@@ -9,7 +9,7 @@
 }
 #skills-section-page {
   max-width: 1200px;
-  margin: 20px auto 60px;
+  margin: 20px auto 0px;
   padding: 0 50px;
   display: flex;
   justify-content: center;
@@ -88,6 +88,9 @@
         transition: all ease-in-out 1s;
         font-weight: bolder;
         scale: 1.25;
+      }
+      &:nth-child(4){
+        margin-bottom: 70px;
       }
     }
   }


### PR DESCRIPTION
## Changes
1. Adjust the `margin-bottom` on three pages 

## Purpose
When the navigation menu opens on mobile, it should occupy the whole screen.

## Approach
These three pages had a margin-bottom set to a certain pixel and it was added at the parent div, which is causing unwanted whitespace when the navigation menu opens on mobile. To resolve the issue, I set the margin-bottom to 0px on two pages only (header and skills) and add a margin-bottom at each page's last-child component. However, for the About page, removing the margin-bottom will make the page look a lot stranger so I decided to decrease the margin from 100px to 30px.

## Learning

Closes #107 
