### PR TITLE
feat(navigation): add margin to the first and last links

### DIFF
--- a/src/client/src/app/components/navigation/navigation.component.scss
+++ b/src/client/src/app/components/navigation/navigation.component.scss
@@ -56,7 +56,13 @@
       height: 100%;
 
       &-link{
-       @include navLinks(30px 20px 40px, 20px)
+       @include navLinks(30px 20px 40px, 20px);
+        &:nth-child(1){
+          margin-top: 120px;
+        }
+        &:last-child{
+          margin-bottom: 120px;
+        }
       }
 
       .links-container {
@@ -129,7 +135,7 @@
       }
 
       #toggle:checked ~ .links-container {
-        height: 100vh;
+        height: 95vh;
         max-height: 100%;
       }
     }


### PR DESCRIPTION
## Changes
1. Adjust height of the nav link container
2. Add margin-top on the first link and margin-bottom on the last link

## Purpose
Increase whitespace around the navigation links to match the Figma design

## Approach
The navigation links look more centered-like by implementing the margin properties

## Learning


Closes #110
