### PR TITLE
Gsa 118 include vendor prefixes css

### DIFF
--- a/src/client/src/app/components/contents/about/about/about.component.scss
+++ b/src/client/src/app/components/contents/about/about/about.component.scss
@@ -11,14 +11,32 @@
   margin: 70px auto 30px;
   padding: 0 30px;
   border-radius: 100px 10px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  flex-flow: column nowrap;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+          flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   border-top-left-radius: 150px 150px;
   --border-size: 0.3rem;
   border: var(--border-size) solid transparent;
   background: rgba( 255, 255, 255, 0.1 );
+  background: -o-linear-gradient(
+    274deg,
+    rgba(243, 243, 243, 0.367) 17%,
+    rgba(231,173,153,1) 52%,
+     rgba(45,228,254,1) 100%),
+  conic-gradient(
+    from var(--angle),
+    #CF9490 0deg 90deg,
+    #D3B970 90deg 180deg,
+    #92ccad 180deg 270deg,
+    #2DE4FE 270deg 360deg
+  );
   background: linear-gradient(
     176deg,
     rgba(243, 243, 243, 0.367) 17%,
@@ -32,22 +50,32 @@
     #2DE4FE 270deg 360deg
   );
   -webkit-backdrop-filter: blur( 20px );
-  box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.45 );
+  -webkit-box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.45 );
+          box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.45 );
   backdrop-filter: blur( 20px );
   background-origin: border-box;
   background-clip: padding-box, border-box;
-  animation: rotate 12s linear infinite, opacityChange 6s infinite alternate;
+  -webkit-animation: rotate 12s linear infinite, opacityChange 6s infinite alternate;
+          animation: rotate 12s linear infinite, opacityChange 6s infinite alternate;
 
 
   .about-me-title {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    justify-content: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     padding: 50px 20px;
   }
 
   .id-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    justify-content: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     margin: 10px auto;
   }
 
@@ -91,8 +119,12 @@
     }
   }
   .images-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    justify-content:space-between;
+    -webkit-box-pack:justify;
+        -ms-flex-pack:justify;
+            justify-content:space-between;
 
     .garfield-image-section {
       position: relative;
@@ -139,8 +171,12 @@
       }
     }
     .images-section {
-      justify-content: center;
-      align-items: center;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center;
 
       .garfield-image-section {
         margin-top: 30px;
@@ -173,11 +209,24 @@
   }
 }
 
+@-webkit-keyframes opacityChange {
+  to {
+    --opacity: 1;
+  }
+}
+
 @keyframes opacityChange {
   to {
     --opacity: 1;
   }
 }
+
+@-webkit-keyframes rotate
+ {
+  to {
+    --angle: 360deg;
+  }
+ }
 
 @keyframes rotate
  {

--- a/src/client/src/app/components/contents/contact/contact/contact.component.scss
+++ b/src/client/src/app/components/contents/contact/contact/contact.component.scss
@@ -3,30 +3,50 @@
 // Desktop and wide screen displays
 
 #contact-form-section-page {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-flow: column nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+          flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   max-width: 950px;
   margin: 70px auto 20px;
   padding: 0 50px;
 
   .contact-title-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    align-self: center;
+    -ms-flex-item-align: center;
+        -ms-grid-row-align: center;
+        align-self: center;
     margin-bottom: 40px;
   }
 
   .form-body-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    flex-direction: column;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
     padding: 0;
     gap: 1rem;
     width: 100%;
-    justify-content: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
 
     .email-address-section {
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      flex-direction: row;
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
       gap: 1rem;
       max-width: 1200px;
       width: 100%;
@@ -40,9 +60,16 @@
       }
 
       .email-input {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        flex-direction: column;
-        justify-content: center;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -webkit-box-pack: center;
+            -ms-flex-pack: center;
+                justify-content: center;
         width: 100%;
         gap: 0.5rem;
 
@@ -56,9 +83,16 @@
     }
 
     .email-body-section {
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      flex-direction: column;
-      justify-content: center;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: column;
+              flex-direction: column;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       gap: 0.5rem;
 
 
@@ -82,10 +116,17 @@
       }
     }
     .call-of-action-section{
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      flex-direction: row;
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
       gap: 1.25rem;
-      justify-content: center;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       margin-top: 20px;
 
       .send-button-block .send-button, .reset-button-block .reset-button {
@@ -95,8 +136,12 @@
   }
 }
 .contact-image-section{
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin-top: -50px;
 }
 
@@ -113,7 +158,10 @@
 
     .form-body-section{
       .email-address-section{
-        flex-direction: column;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
         gap: 0.5rem;
 
         label {
@@ -123,7 +171,9 @@
         }
 
         .email-input {
-          align-items: center;
+          -webkit-box-align: center;
+              -ms-flex-align: center;
+                  align-items: center;
           gap: 0.5rem;
 
           .error-alert span {
@@ -136,13 +186,17 @@
         }
       }
       .email-body-section{
-        align-items: center;
+        -webkit-box-align: center;
+            -ms-flex-align: center;
+                align-items: center;
 
         label {
           font-size: 20px;
           padding: 0;
           margin: 0 1.5em;
-          align-self: start;
+          -ms-flex-item-align: start;
+              -ms-grid-row-align: start;
+              align-self: start;
         }
 
         textarea {
@@ -156,14 +210,23 @@
         }
       }
       .call-of-action-section{
-        flex-direction: column;
-        align-items: center;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -webkit-box-align: center;
+            -ms-flex-align: center;
+                align-items: center;
 
         .send-button-block .send-button .reset-button-block .reset-button {
           width: 200px;
           max-width: 90%;
+          display: -webkit-box;
+          display: -ms-flexbox;
           display: flex;
-          justify-content: center;
+          -webkit-box-pack: center;
+              -ms-flex-pack: center;
+                  justify-content: center;
         }
       }
     }
@@ -174,16 +237,23 @@
 }
 
 
-// CSS styles for the two confirmaiton templates
+// CSS styles for the two confirmation templates
 .confirmation-template{
   font-family: 'Playfair Display';
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   margin: auto;
-  max-width : 70%;
+  max-width: 70%;
   padding: 15px 20px;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 
   span {
     font-size: 20px;

--- a/src/client/src/app/components/contents/contributions/contributions/projects.component.scss
+++ b/src/client/src/app/components/contents/contributions/contributions/projects.component.scss
@@ -5,59 +5,103 @@
   max-width: 1200px;
   margin: 50px auto 0;
   padding: 0 60px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 
   .projects-title-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     padding-bottom: 20px;
   }
 
   .project-blocks-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    flex-wrap: row nowrap;
+    -ms-flex-wrap: row nowrap;
+        flex-wrap: row nowrap;
     gap: 3.5rem;
     padding: 30px 20px;
 
     .project-block {
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      flex-direction: column;
-      justify-content: center;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: column;
+              flex-direction: column;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       background: #FFFFFF;
-      box-shadow: 7px 4px 4px 6px rgba(73, 88, 103, 0.25), 15px 6px 4px 6px rgba(193, 140, 93, 0.25), 20px 10px 4px 6px rgba(206, 121, 107, 0.25);
+      -webkit-box-shadow: 7px 4px 4px 6px rgba(73, 88, 103, 0.25), 15px 6px 4px 6px rgba(193, 140, 93, 0.25), 20px 10px 4px 6px rgba(206, 121, 107, 0.25);
+              box-shadow: 7px 4px 4px 6px rgba(73, 88, 103, 0.25), 15px 6px 4px 6px rgba(193, 140, 93, 0.25), 20px 10px 4px 6px rgba(206, 121, 107, 0.25);
       border-radius: 50px 0px;
       padding: 30px 23px;
       width: 80%;
-      animation-delay: -1s;
-      animation-duration: 6s;
-      animation-fill-mode: none;
-      animation-timing-function: ease-in-out;
-      animation-iteration-count: infinite;
+      -webkit-animation-delay: -1s;
+              animation-delay: -1s;
+      -webkit-animation-duration: 6s;
+              animation-duration: 6s;
+      -webkit-animation-fill-mode: none;
+              animation-fill-mode: none;
+      -webkit-animation-timing-function: ease-in-out;
+              animation-timing-function: ease-in-out;
+      -webkit-animation-iteration-count: infinite;
+              animation-iteration-count: infinite;
 
       &:hover {
-        animation-name: bounce;
+        -webkit-animation-name: bounce;
+                animation-name: bounce;
         cursor: pointer;
       }
 
       .title-section{
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        justify-content: center;
+        -webkit-box-pack: center;
+            -ms-flex-pack: center;
+                justify-content: center;
         h5 {
           text-align: center;
         }
       }
       .image-section {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        align-self: center;
+        -ms-flex-item-align: center;
+            -ms-grid-row-align: center;
+            align-self: center;
       }
       .description {
         padding: 25px 0 10px;
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        justify-content: center;
+        -webkit-box-pack: center;
+            -ms-flex-pack: center;
+                justify-content: center;
         p {
           line-height: 110%;
           font-size: 20px;
@@ -65,8 +109,12 @@
         }
       }
       .technologies {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        justify-content: center;
+        -webkit-box-pack: center;
+            -ms-flex-pack: center;
+                justify-content: center;
         padding: 15px 0 20px;
         p {
           font-size: 20px;
@@ -75,17 +123,30 @@
         }
       }
       .demo-section {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        flex-direction: column;
-        align-self: center;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -ms-flex-item-align: center;
+            -ms-grid-row-align: center;
+            align-self: center;
         gap: 1rem;
       }
     }
   }
   .my-image-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    align-self: center;
-    justify-content: center;
+    -ms-flex-item-align: center;
+        -ms-grid-row-align: center;
+        align-self: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     z-index: 2;
   }
   .portfolio-detail-section {
@@ -93,7 +154,8 @@
     width: 100%;
     height: 200px;
     background:rgba(206, 121, 107, 0.2);
-    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+    -webkit-box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+            box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
     border-radius: 50px 0;
     margin-bottom: 20px;
     position: relative;
@@ -108,20 +170,42 @@
     }
 
     .links-section-container {
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      justify-content: center;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       margin: 5px 0;
 
       .link-section {
-        flex-direction: column;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
         margin-bottom: 5px;
 
         a {
+          display: -webkit-box;
+          display: -ms-flexbox;
           display: flex;
-          flex-direction: row;
-          background-clip: text;
+          -webkit-box-orient: horizontal;
+          -webkit-box-direction: normal;
+              -ms-flex-direction: row;
+                  flex-direction: row;
+          -webkit-background-clip: text;
+                  background-clip: text;
           -webkit-bakcground-clip: text;
           -webkit-text-fill-color: transparent;
+          background-image : -webkit-gradient(
+            linear,
+            left top, right top,
+            from(rgba(131,58,180,1)), color-stop(80%, rgba(253,29,29,1)), to(rgba(252,176,89,1))
+          );
+          background-image : -o-linear-gradient(
+            left,
+            rgba(131,58,180,1) 0%, rgba(253,29,29,1) 80%, rgba(252,176,89,1) 100%
+          );
           background-image : linear-gradient(
             to right,
             rgba(131,58,180,1) 0%, rgba(253,29,29,1) 80%, rgba(252,176,89,1) 100%
@@ -136,8 +220,12 @@
           }
 
           p {
+            display: -webkit-box;
+            display: -ms-flexbox;
             display: flex;
-            align-self: center;
+            -ms-flex-item-align: center;
+                -ms-grid-row-align: center;
+                align-self: center;
             color: $color__blackCoral;
             padding-left: 10px;
             line-height: 1;
@@ -146,6 +234,8 @@
           }
 
           &:hover {
+            -webkit-transition: all 0.3s cubic-bezier(0.000, 0.000, 0.230, 1);
+            -o-transition: all 0.3s cubic-bezier(0.000, 0.000, 0.230, 1);
             transition: all 0.3s cubic-bezier(0.000, 0.000, 0.230, 1);
             background-position: 0%;
             p {
@@ -165,9 +255,16 @@
    padding: 0 10px;
 
    .project-blocks-section{
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
 
     .project-block {
       max-width: 73%;
@@ -182,9 +279,16 @@
         }
       }
       .demo-section {
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -webkit-box-pack: center;
+            -ms-flex-pack: center;
+                justify-content: center;
+        -webkit-box-align: center;
+            -ms-flex-align: center;
+                align-items: center;
        }
     }
 //  certain blocks are temporarily hidden as the data perceived are static.
@@ -216,17 +320,40 @@
   }
 }
 
-@keyframes bounce {
+@-webkit-keyframes bounce {
   0%, 100%, 20%, 50%, 70% {
-    transform: translateY(0);
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
   }
   40% {
-    transform: translateY(-15px);
+    -webkit-transform: translateY(-15px);
+            transform: translateY(-15px);
   }
   60% {
-    transform: translateY(-30px);
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
   }
   90% {
-    transform: translateY(-45px);
+    -webkit-transform: translateY(-45px);
+            transform: translateY(-45px);
+  }
+}
+
+@keyframes bounce {
+  0%, 100%, 20%, 50%, 70% {
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
+  }
+  40% {
+    -webkit-transform: translateY(-15px);
+            transform: translateY(-15px);
+  }
+  60% {
+    -webkit-transform: translateY(-30px);
+            transform: translateY(-30px);
+  }
+  90% {
+    -webkit-transform: translateY(-45px);
+            transform: translateY(-45px);
   }
 }

--- a/src/client/src/app/components/contents/header/header/header.component.scss
+++ b/src/client/src/app/components/contents/header/header/header.component.scss
@@ -1,9 +1,15 @@
 @import '../../../../../styles';
 
 @mixin displayLayout($justify-content, $align-item){
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: $justify-content;
-  align-items: $align-item;
+  -webkit-box-pack: $justify-content;
+      -ms-flex-pack: $justify-content;
+          justify-content: $justify-content;
+  -webkit-box-align: $align-item;
+      -ms-flex-align: $align-item;
+          align-items: $align-item;
 }
 
 // Desktop and wide screen
@@ -13,17 +19,22 @@
   width: 100%;
   margin: 30px auto 0px;
   padding: 0 30px;
+  display: -ms-grid;
   display: grid;
+  -ms-grid-columns: 1.10fr 0.75rem 1fr;
   grid-template-columns: 1.10fr 1fr;
+  -ms-grid-rows: auto 0.75rem 60px 0.75rem 60px 0.75rem 120px;
   grid-template-rows: auto 60px 60px 120px;
 
   .header-section-memoji {
+    -ms-grid-row-span: 4;
     grid-row-end: span 4;
     width: 100%;
     height: 100%;
 
     .memoji-block {
-      object-fit: cover;
+      -o-object-fit: cover;
+         object-fit: cover;
       width: 100%;
       height: 100%;
     }
@@ -64,7 +75,10 @@
 
   .contact-links-section {
     @include displayLayout(flex-start, center);
-    flex-direction: row;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
     gap: 1rem;
     padding-left: 50px;
 
@@ -93,43 +107,137 @@
     }
     .social-media-icons-section {
       @include displayLayout(center, center);
-      flex-direction: row;
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
       gap: 0.75rem;
 
         .sm-icon{
           width: 100%;
 
           &:hover, &:focus {
-            transform: scale(1.25);
+            -webkit-transform: scale(1.25);
+                -ms-transform: scale(1.25);
+                    transform: scale(1.25);
+            -webkit-transition: all 0.3s ease;
+            -o-transition: all 0.3s ease;
             transition: all 0.3s ease;
           }
 
           &:active {
-            transform: scale(1);
+            -webkit-transform: scale(1);
+                -ms-transform: scale(1);
+                    transform: scale(1);
           }
         }
     }
   }
 }
 
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(1) {
+//   -ms-grid-row: 1;
+//   grid-row: 1;
+//   -ms-grid-column: 1;
+//   grid-column: 1;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(2) {
+//   -ms-grid-row: 1;
+//   grid-row: 1;
+//   -ms-grid-column: 3;
+//   grid-column: 3;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(3) {
+//   -ms-grid-row: 3;
+//   grid-row: 3;
+//   -ms-grid-column: 1;
+//   grid-column: 1;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(4) {
+//   -ms-grid-row: 3;
+//   grid-row: 3;
+//   -ms-grid-column: 3;
+//   grid-column: 3;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(5) {
+//   -ms-grid-row: 5;
+//   grid-row: 5;
+//   -ms-grid-column: 1;
+//   grid-column: 1;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(6) {
+//   -ms-grid-row: 5;
+//   grid-row: 5;
+//   -ms-grid-column: 3;
+//   grid-column: 3;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(7) {
+//   -ms-grid-row: 7;
+//   grid-row: 7;
+//   -ms-grid-column: 1;
+//   grid-column: 1;
+// }
+
+// // Desktop and wide screen
+
+// #header-section > *:nth-child(8) {
+//   -ms-grid-row: 7;
+//   grid-row: 7;
+//   -ms-grid-column: 3;
+//   grid-column: 3;
+// }
+
 // Mobile Screens : 991.98px and below
 #header-section {
   @media (max-width: $size__standard-mobile){
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    flex-flow: column wrap;
-    align-items: center;
-    justify-content: center;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-flow: column wrap;
+            flex-flow: column wrap;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
     line-height: 100%;
 
 
     .header-section-memoji {
       width: 300px;
       height: 250px;
-      order: 1;
+      -webkit-box-ordinal-group: 2;
+          -ms-flex-order: 1;
+              order: 1;
     }
 
     .first-phrase-section {
-      order: 2;
+      -webkit-box-ordinal-group: 3;
+          -ms-flex-order: 2;
+              order: 2;
       margin-top: 20px;
       p {
        padding: 0;
@@ -138,8 +246,11 @@
     }
 
     .name-title-section {
-      justify-self: start;
-      order: 3;
+      -ms-grid-column-align: start;
+          justify-self: start;
+      -webkit-box-ordinal-group: 4;
+          -ms-flex-order: 3;
+              order: 3;
       h1 {
         padding-left: 0;
         margin-left: 0;
@@ -147,7 +258,9 @@
     }
 
   .job-title-section {
-    order: 4;
+    -webkit-box-ordinal-group: 5;
+        -ms-flex-order: 4;
+            order: 4;
 
     h2 {
       padding-left: 0;
@@ -159,16 +272,27 @@
   .contact-links-section {
     padding-left: 0;
     margin-top: 25px;
-    justify-content: center;
-    flex-direction: column;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
     margin-bottom: 30px;
-    order: 5;
+    -webkit-box-ordinal-group: 6;
+        -ms-flex-order: 5;
+            order: 5;
 
     .get-in-touch-section {
       font-size: 18px;
       line-height: 100%;
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      justify-content: center;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       text-align: center;
 
       a {
@@ -177,7 +301,10 @@
     }
 
     .social-media-icons-section {
-      flex-direction: row;
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row;
       width: 75%;
     }
   }

--- a/src/client/src/app/components/contents/skills/skills/skills.component.scss
+++ b/src/client/src/app/components/contents/skills/skills/skills.component.scss
@@ -2,28 +2,46 @@
 
 // Desktop and Wide Screen Responsiveness
 .skills-title-section{
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   margin: 50px auto;
 }
 #skills-section-page {
   max-width: 1200px;
   margin: 20px auto 0px;
   padding: 0 50px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  flex-flow: row nowrap;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+          flex-flow: row nowrap;
   -ms-flex-flow: row nowrap;
   width: 100%;
   height: auto;
 
   .memoji-section{
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    justify-content: flex-start;
-    object-fit: cover;
+    -webkit-box-pack: start;
+        -ms-flex-pack: start;
+            justify-content: flex-start;
+    -o-object-fit: cover;
+       object-fit: cover;
     width: 100%;
-    flex-basis: 60%;
+    -ms-flex-preferred-size: 60%;
+        flex-basis: 60%;
 
     img {
       max-width: 90%;
@@ -31,28 +49,54 @@
   }
 
   .tech-skills-blocks-section {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
-    justify-content: flex-start;
-    flex-shrink: 25%;
-    flex-flow: column nowrap;
+    -webkit-box-pack: start;
+        -ms-flex-pack: start;
+            justify-content: flex-start;
+    -ms-flex-negative: 25%;
+        flex-shrink: 25%;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-flow: column nowrap;
+            flex-flow: column nowrap;
     gap: 2.5rem;
 
     .frontend-block, .other-tools-block {
       max-width: 500px;
       padding: 20px 40px;
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      flex-direction: column;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
+      -webkit-box-align: start;
+          -ms-flex-align: start;
+              align-items: flex-start;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: column;
+              flex-direction: column;
     }
 
     .backend-block, .learning-block {
       max-width: 500px;
       padding: 20px 40px;
+      display: -webkit-box;
+      display: -ms-flexbox;
       display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      flex-direction: column;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
+      -webkit-box-align: start;
+          -ms-flex-align: start;
+              align-items: flex-start;
+      -webkit-box-orient: vertical;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: column;
+              flex-direction: column;
 
       h5, p {
         color: $color__text-main-third;
@@ -61,13 +105,17 @@
 
     .lighter-skill-block {
       background: $color__background-skills_light;
-      filter: drop-shadow(10px 10px 9px rgba(206, 121, 107, 0.25));
+      -webkit-filter: drop-shadow(10px 10px 9px rgba(206, 121, 107, 0.25));
+              filter: drop-shadow(10px 10px 9px rgba(206, 121, 107, 0.25));
       border: 1px solid $color__border-skills-newyorkpink;
       border-radius: 30px;
 
       &:hover {
         background: rgb(236,200,175);
+        background: -o-radial-gradient(circle, rgba(236,200,175,0.36738445378151263) 26%, rgba(231,173,153,1) 73%, rgba(73,88,103,1) 100%);
         background: radial-gradient(circle, rgba(236,200,175,0.36738445378151263) 26%, rgba(231,173,153,1) 73%, rgba(73,88,103,1) 100%);
+        -webkit-transition: all ease-in-out 1s;
+        -o-transition: all ease-in-out 1s;
         transition: all ease-in-out 1s;
         font-weight: bolder;
         scale: 1.25;
@@ -77,14 +125,18 @@
 
     .darker-skill-block {
       background: $color__background-skills_dark;
-      filter: drop-shadow(10px 10px 9px rgba(73, 88, 103, 0.25));
+      -webkit-filter: drop-shadow(10px 10px 9px rgba(73, 88, 103, 0.25));
+              filter: drop-shadow(10px 10px 9px rgba(73, 88, 103, 0.25));
       border: 1px solid $color__border-skills-blackcoral;
       border-radius: 30px;
 
       &:hover {
         border: 1px solid $color__border-skills-newyorkpink;
         background: rgb(73,88,103);
+        background: -o-radial-gradient(circle, rgba(73,88,103,1) 26%, rgba(231,173,153,1) 83%, rgba(236,200,175,0.36738445378151263) 100%);
         background: radial-gradient(circle, rgba(73,88,103,1) 26%, rgba(231,173,153,1) 83%, rgba(236,200,175,0.36738445378151263) 100%);
+        -webkit-transition: all ease-in-out 1s;
+        -o-transition: all ease-in-out 1s;
         transition: all ease-in-out 1s;
         font-weight: bolder;
         scale: 1.25;
@@ -106,12 +158,16 @@
 
   #skills-section-page {
     padding: 0 30px;
-    flex-flow: column nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+            flex-flow: column nowrap;
     -ms-flex-flow: column nowrap;
     gap: 0.5rem;
 
     .memoji-section{
-      justify-content: center;
+      -webkit-box-pack: center;
+          -ms-flex-pack: center;
+              justify-content: center;
       img {
         max-width: 80%;
       }
@@ -121,7 +177,9 @@
 
       .frontend-block, .other-tools-block, .backend-block, .learning-block {
         padding: 15px 25px;
-        align-self: center;
+        -ms-flex-item-align: center;
+            -ms-grid-row-align: center;
+            align-self: center;
         width: 80%;
       }
     }

--- a/src/client/src/app/components/navigation/navigation.component.scss
+++ b/src/client/src/app/components/navigation/navigation.component.scss
@@ -3,11 +3,15 @@
 @mixin navBackground($padding, $gap){
   background: $color__navigation-body;
   padding: $padding;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   gap: $gap;
 }
 
 @mixin navLinks($padding, $fontsize){
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   padding: $padding;
   font-size: $fontsize;
@@ -28,9 +32,16 @@
 
   .navigation-section {
     @include navBackground(25px 40px, 1.5rem);
-    flex-direction: row;
-    justify-content: center;
-    align-items:center;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+    -webkit-box-align:center;
+        -ms-flex-align:center;
+            align-items:center;
 
     &-link {
       @include navLinks(0 20px, 24px);
@@ -69,24 +80,44 @@
         width: 100%;
         background-color: $color__navigation-body;
         margin: 0;
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: center;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -webkit-box-pack: start;
+            -ms-flex-pack: start;
+                justify-content: flex-start;
+        -webkit-box-align: center;
+            -ms-flex-align: center;
+                align-items: center;
         padding: 0;
         list-style: none;
         clear: both;
         width: auto;
         height: 0px;
         overflow: hidden;
+        -webkit-transition: height .4s ease;
+        -o-transition: height .4s ease;
         transition: height .4s ease;
         z-index: 10;
+        -webkit-transition: all 0.3s ease;
+        -o-transition: all 0.3s ease;
         transition: all 0.3s ease;
 
         a {
-          flex-direction: column;
-          justify-content: center;
-          align-items: center;
+          -webkit-box-orient: vertical;
+          -webkit-box-direction: normal;
+              -ms-flex-direction: column;
+                  flex-direction: column;
+          -webkit-box-pack: center;
+              -ms-flex-pack: center;
+                  justify-content: center;
+          -webkit-box-align: center;
+              -ms-flex-align: center;
+                  align-items: center;
         }
       }
 
@@ -95,6 +126,7 @@
         padding: 20px;
         display: -ms-grid;
         display: grid;
+
         grid-template-rows: repeat(3, 1fr);
         justify-items: center;
         position: relative;
@@ -106,6 +138,8 @@
           width: 40px;
           height: 5px;
           margin-top: 7px;
+          -webkit-transition: all 0.1s ease-in-out;
+          -o-transition: all 0.1s ease-in-out;
           transition: all 0.1s ease-in-out;
           cursor: pointer;
           border-radius: 30px;
@@ -118,20 +152,23 @@
 
       #toggle:checked + .hamburger .top {
         -webkit-transform: rotate(-45deg);
-        transform: rotate(-45deg);
+        -ms-transform: rotate(-45deg);
+            transform: rotate(-45deg);
         margin-top: 22.5px;
 
       }
 
       #toggle:checked + .hamburger .middle {
         -webkit-transform: rotate(45deg);
-        transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+            transform: rotate(45deg);
         margin-top: -5px;
       }
 
       #toggle:checked + .hamburger .bottom {
         -webkit-transform: scale(0);
-        transform: scale(0);
+        -ms-transform: scale(0);
+            transform: scale(0);
       }
 
       #toggle:checked ~ .links-container {

--- a/src/client/src/styles/base/elements/_buttons.scss
+++ b/src/client/src/styles/base/elements/_buttons.scss
@@ -2,9 +2,20 @@
 @import '../../variables/structure';
 
 
+/*
+* Prefixed by https://autoprefixer.github.io
+* PostCSS: v8.4.14,
+* Autoprefixer: v10.4.7
+* Browsers: last 4 version
+*/
+
 @mixin buttonProperties() {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   text-align: center;
   font-style: normal;
   padding: 10px 20px;
@@ -22,6 +33,8 @@ input[type="submit"] {
   &:hover, &:focus, &:active {
     background: $color__background-button-hover;
     color: $color__button-link-hover;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
     transition: all 0.3s ease-out;
   }
 }
@@ -35,6 +48,9 @@ input[type="submit"] {
   font-size: 20px;
   font-weight: 600;
   font-family: 'Playfair Display', serif;
+  -webkit-transition: all 0.1s ease-out;
+  -o-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
 
 
   @media (max-width: $size__standard-mobile) {
@@ -44,6 +60,8 @@ input[type="submit"] {
   &:hover, &:focus {
     background: $color__background-button-hover;
     color: $color__button-link-hover;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
     transition: all 0.3s ease-out;
   }
 }
@@ -57,6 +75,9 @@ input[type="submit"] {
   font-size: 20px;
   font-weight: 600;
   font-family: 'Playfair Display', serif;
+  -webkit-transition: all 0.1s ease-out;
+  -o-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
 
   @media (max-width: $size__standard-mobile) {
     font-size: 18px;
@@ -65,6 +86,8 @@ input[type="submit"] {
   &:hover, &:focus {
     background: $color__background-button-hover;
     color: $color__button-link-hover;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
     transition: all 0.3s ease-out;
   }
 }

--- a/src/client/src/styles/base/elements/_links.scss
+++ b/src/client/src/styles/base/elements/_links.scss
@@ -11,6 +11,8 @@
     position: absolute;
     top: $top;
     left: 0;
+    -webkit-transition: all 0.5s;
+    -o-transition: all 0.5s;
     transition: all 0.5s;
   }
 
@@ -22,17 +24,23 @@
     position: absolute;
     top: $top;
     right: 0;
+    -webkit-transition: all 0.5s;
+    -o-transition: all 0.5s;
     transition: all 0.5s;
   }
 
   &:hover:before {
     width: 50%;
-    transform: translateX(100%);
+    -webkit-transform: translateX(100%);
+        -ms-transform: translateX(100%);
+            transform: translateX(100%);
   }
 
   &:hover:after {
     width: 50%;
-    transform: translateX(-100%);
+    -webkit-transform: translateX(-100%);
+        -ms-transform: translateX(-100%);
+            transform: translateX(-100%);
   }
 }
 

--- a/src/client/src/styles/generic/_normalize.scss
+++ b/src/client/src/styles/generic/_normalize.scss
@@ -2,7 +2,8 @@
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 /* Remove default margin */
@@ -39,7 +40,8 @@ body {
 
 /* A elements that don't have a class get default styles */
 a:not([class]) {
-  text-decoration-skip-ink: auto;
+  -webkit-text-decoration-skip: ink;
+          text-decoration-skip-ink: auto;
 }
 
 /* Make images easier to work with */
@@ -66,10 +68,15 @@ select {
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    -webkit-animation-duration: 0.01ms !important;
+            animation-duration: 0.01ms !important;
+    -webkit-animation-iteration-count: 1 !important;
+            animation-iteration-count: 1 !important;
+    -webkit-transition-duration: 0.01ms !important;
+         -o-transition-duration: 0.01ms !important;
+            transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
 }
+
 


### PR DESCRIPTION
## Changes
1. Used a css plugin to automatically add the vendor prefixes 

## Purpose
Make the project work on different common browsers such as Safari, Opera, Mozilla, Chrome, and Edge 

## Approach
I discovered autoprefixer, a CSS plugin deployed through github, that automatically add new vendor prefixes so the style or animation will work on different browsers. However, the plugin does not automatically generate `-moz-` prefix.

## Learning
https://autoprefixer.github.io/

Closes #118
