### PR TITLE
Gsa 24 modal scrollbar modification

### DIFF
--- a/src/client/src/app/components/contents/about/about/about.component.ts
+++ b/src/client/src/app/components/contents/about/about/about.component.ts
@@ -16,6 +16,8 @@ export class AboutComponent implements OnInit {
   }
 
   openModal(){
-    this.modalRef = this.modalService.open(ModalComponent)
+    this.modalRef = this.modalService.open(ModalComponent, {
+      modalClass: 'modal-lg'
+    })
   }
 }

--- a/src/client/src/app/components/modal/modal.component.html
+++ b/src/client/src/app/components/modal/modal.component.html
@@ -12,7 +12,7 @@
     [src]="pdfSrc"
     [render-text]="false"
     [original-size]="true"
-    style=" height: 800px"
+    class="modal-section"
   >
   </pdf-viewer>
 </div>

--- a/src/client/src/app/components/modal/modal.component.scss
+++ b/src/client/src/app/components/modal/modal.component.scss
@@ -1,0 +1,3 @@
+.modal-section {
+   height: 76vh;
+}


### PR DESCRIPTION
## Changes
1. Remove the instyle property in the HTML file
2. On the about ts file, I passed a second argument that passes a modal object configuration property
3. Adjust the modal height to 75vh as a workaround for the scroll property. 

## Purpose
When the modal opens, an unwanted scrollbar appears on the browser.

## Approach
By adjusting the modal height, I do not need to worry about adjusting the overflow css property of it, and by passing a second argument in the openModal function , it allowed me to implement one of the mdb's built in class for modal

## Learning

Closes #124 
